### PR TITLE
Updated name, fixed cached_property fatal error

### DIFF
--- a/joombrute.py
+++ b/joombrute.py
@@ -5,6 +5,8 @@
 # Requirements: pip install robobrowser 
 # python 2.7
 
+import werkzeug
+werkzeug.cached_property = werkzeug.utils.cached_property
 from robobrowser import RoboBrowser
 import re,sys,time,argparse,warnings
 from random import randint


### PR DESCRIPTION
I found the solution by using this python3 post to deal with the exact same issue, https://stackoverflow.com/questions/46457179/python3-cannot-import-name-cached-property, so I added the following changes to deal with the critical error:  ImportError: cannot import name 'cached_property'

import werkzeug
werkzeug.cached_property = werkzeug.utils.cached_property